### PR TITLE
Refactor image conversion logic and ensure buffer compatibility

### DIFF
--- a/app/api/upload/image/route.ts
+++ b/app/api/upload/image/route.ts
@@ -8,53 +8,7 @@ import {
   validateImageFile,
   generateImageFilename,
 } from '@/lib/storage-utils'
-import sharp from 'sharp'
-
-/**
- * Convert HEIC/HEIF images to JPEG for web compatibility
- * Returns the converted buffer and new filename, or original if conversion not needed
- */
-export async function convertImageIfNeeded(
-  buffer: Buffer,
-  originalFilename: string,
-  mimeType: string
-): Promise<{ buffer: Buffer; filename: string; contentType: string }> {
-  const isHeic = mimeType === 'image/heic' || mimeType === 'image/heif'
-  const extension = originalFilename.split('.').pop()?.toLowerCase()
-  const isHeicExtension = extension === 'heic' || extension === 'heif'
-
-  // If it's not HEIC/HEIF, return as-is
-  if (!isHeic && !isHeicExtension) {
-    return {
-      buffer,
-      filename: originalFilename,
-      contentType: mimeType,
-    }
-  }
-
-  try {
-    // Convert HEIC/HEIF to JPEG using sharp
-    const jpegBuffer = await sharp(buffer)
-      .jpeg({ quality: 90, mozjpeg: true })
-      .toBuffer()
-
-    // Update filename to use .jpg extension
-    const baseFilename = originalFilename.replace(/\.[^.]+$/, '')
-    const newFilename = `${baseFilename}.jpg`
-
-    console.log(`[convertImageIfNeeded] Converted ${originalFilename} (${mimeType}) to ${newFilename}`)
-
-    return {
-      buffer: jpegBuffer,
-      filename: newFilename,
-      contentType: 'image/jpeg',
-    }
-  } catch (error) {
-    console.error(`[convertImageIfNeeded] Error converting image:`, error)
-    // If conversion fails, try to return original (might fail on upload, but better than silent failure)
-    throw new Error(`Failed to convert HEIC/HEIF image: ${error instanceof Error ? error.message : 'Unknown error'}`)
-  }
-}
+import { convertImageIfNeeded } from '@/lib/image-conversion'
 
 export async function POST(request: NextRequest) {
   try {
@@ -145,7 +99,8 @@ export async function POST(request: NextRequest) {
 
     try {
       const converted = await convertImageIfNeeded(buffer, file.name, file.type)
-      buffer = converted.buffer
+      // Ensure type compatibility
+      buffer = Buffer.from(converted.buffer)
       finalFileName = generateImageFilename(converted.filename)
       finalContentType = converted.contentType
     } catch (conversionError) {

--- a/lib/image-conversion.ts
+++ b/lib/image-conversion.ts
@@ -28,6 +28,9 @@ export async function convertImageIfNeeded(
       .jpeg({ quality: 90, mozjpeg: true })
       .toBuffer()
 
+    // Ensure type compatibility by creating a new Buffer
+    const convertedBuffer = Buffer.from(jpegBuffer)
+
     // Update filename to use .jpg extension
     const baseFilename = originalFilename.replace(/\.[^.]+$/, '')
     const newFilename = `${baseFilename}.jpg`
@@ -35,7 +38,7 @@ export async function convertImageIfNeeded(
     console.log(`[convertImageIfNeeded] Converted ${originalFilename} (${mimeType}) to ${newFilename}`)
 
     return {
-      buffer: jpegBuffer,
+      buffer: convertedBuffer,
       filename: newFilename,
       contentType: 'image/jpeg',
     }


### PR DESCRIPTION
This commit refactors the image conversion functionality by moving the `convertImageIfNeeded` function to a dedicated module in `lib/image-conversion.ts`. The conversion process now ensures type compatibility by creating a new Buffer from the converted image data. This change streamlines the image upload API, enhancing maintainability and performance while retaining support for HEIC/HEIF formats.