### PR TITLE
Add SMS consent functionality with API endpoint and UI components

### DIFF
--- a/app/api/sms-consent/route.ts
+++ b/app/api/sms-consent/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { supabaseService } from '@/lib/supabase-service'
+import { getWeddingContext } from '@/lib/wedding-context-server'
+import { formatPhoneForTwilio, validatePhoneNumber } from '@/lib/sms-service'
+
+export async function POST(request: NextRequest) {
+  try {
+    const context = await getWeddingContext()
+
+    if (!context) {
+      return NextResponse.json(
+        { success: false, error: 'Wedding context not found' },
+        { status: 404 }
+      )
+    }
+
+    const body = await request.json()
+    const { phone_number, first_name, last_name } = body
+
+    // Validate required fields
+    if (!phone_number) {
+      return NextResponse.json(
+        { success: false, error: 'Phone number is required' },
+        { status: 400 }
+      )
+    }
+
+    // Format and validate phone number
+    const formattedPhone = formatPhoneForTwilio(phone_number)
+
+    if (!validatePhoneNumber(formattedPhone)) {
+      return NextResponse.json(
+        { success: false, error: 'Please enter a valid phone number' },
+        { status: 400 }
+      )
+    }
+
+    const supabase = supabaseService()
+
+    // Get request metadata for audit trail
+    const ip = request.headers.get('x-forwarded-for') || request.headers.get('x-real-ip') || 'unknown'
+    const userAgent = request.headers.get('user-agent') || 'unknown'
+
+    const consentMessage = `I agree to receive SMS notifications about the wedding from ${context.wedding?.couple_display_name || 'the wedding couple'}. Message and data rates may apply. Reply STOP to unsubscribe.`
+
+    // Upsert consent record (update if exists, insert if not)
+    const { data, error } = await supabase
+      .from('sms_consent')
+      .upsert(
+        {
+          wedding_id: context.weddingId,
+          phone_number: formattedPhone,
+          first_name: first_name?.trim() || null,
+          last_name: last_name?.trim() || null,
+          consent_given: true,
+          consent_message: consentMessage,
+          consent_timestamp: new Date().toISOString(),
+          ip_address: ip,
+          user_agent: userAgent,
+          updated_at: new Date().toISOString(),
+        },
+        {
+          onConflict: 'wedding_id,phone_number',
+        }
+      )
+      .select()
+      .single()
+
+    if (error) {
+      console.error('Error saving SMS consent:', error)
+      return NextResponse.json(
+        { success: false, error: 'Failed to save consent. Please try again.' },
+        { status: 500 }
+      )
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: 'Thank you! You will now receive SMS notifications about the wedding.',
+      data: {
+        phone_number: formattedPhone,
+        consent_timestamp: data.consent_timestamp,
+      },
+    })
+  } catch (error) {
+    console.error('SMS consent error:', error)
+    return NextResponse.json(
+      { success: false, error: 'An unexpected error occurred' },
+      { status: 500 }
+    )
+  }
+}
+

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,28 +1,12 @@
-import { getWeddingContext } from '@/lib/wedding-context-server';
+import { getWeddingContext } from '@/lib/wedding-context-server'
+import { FooterClient } from '@/components/FooterClient'
 
-export default async function Footer(){
-  const context = await getWeddingContext();
-  const currentYear = new Date().getFullYear();
-  
+export default async function Footer() {
+  const context = await getWeddingContext()
+  const currentYear = new Date().getFullYear()
+
   // Optionally show wedding name in footer
-  const coupleName = context?.wedding?.couple_display_name;
+  const coupleName = context?.wedding?.couple_display_name
 
-  return (
-    <footer className="border-t border-gold-100/60 bg-white/70 backdrop-blur py-10 animate-in fade-in slide-in-from-bottom-4 duration-500">
-      <div className="mx-auto max-w-6xl px-4 md:px-6 text-center text-sm text-black/70">
-        {coupleName && (
-          <p className="mb-2">{coupleName}</p>
-        )}
-        Made with love by <a 
-          href="https://glumia.com" 
-          className="text-gold-500 hover:text-gold-600 transition-all duration-200 hover:scale-105 active:scale-95"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Glumia
-        </a> • © {currentYear}
-      </div>
-    </footer>
-  )
+  return <FooterClient coupleName={coupleName} currentYear={currentYear} />
 }
-  

--- a/components/FooterClient.tsx
+++ b/components/FooterClient.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import { useState } from 'react'
+import { SmsOptInModal } from '@/components/SmsOptInModal'
+import { MessageSquare } from 'lucide-react'
+
+interface FooterClientProps {
+  coupleName?: string
+  currentYear: number
+}
+
+export const FooterClient = ({ coupleName, currentYear }: FooterClientProps) => {
+  const [smsModalOpen, setSmsModalOpen] = useState(false)
+
+  return (
+    <footer className="border-t border-gold-100/60 bg-white/70 backdrop-blur py-10 animate-in fade-in slide-in-from-bottom-4 duration-500">
+      <div className="mx-auto max-w-6xl px-4 md:px-6 text-center text-sm text-black/70">
+        {coupleName && <p className="mb-2">{coupleName}</p>}
+
+        {/* Footer Links */}
+        <div className="flex items-center justify-center gap-4 mb-3">
+          <button
+            type="button"
+            onClick={() => setSmsModalOpen(true)}
+            className="inline-flex items-center gap-1.5 text-gold-600 hover:text-gold-700 transition-colors duration-200 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gold-500 focus-visible:ring-offset-2 rounded"
+            aria-label="Subscribe to SMS notifications"
+            tabIndex={0}
+          >
+            <MessageSquare className="h-4 w-4" aria-hidden="true" />
+            SMS Notifications
+          </button>
+        </div>
+
+        {/* Made with love */}
+        <div>
+          Made with love by{' '}
+          <a
+            href="https://glumia.com"
+            className="text-gold-500 hover:text-gold-600 transition-all duration-200 hover:scale-105 active:scale-95"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Glumia
+          </a>{' '}
+          • © {currentYear}
+        </div>
+      </div>
+
+      {/* SMS Opt-In Modal */}
+      <SmsOptInModal open={smsModalOpen} onOpenChange={setSmsModalOpen} coupleName={coupleName} />
+    </footer>
+  )
+}
+

--- a/components/SmsOptInModal.tsx
+++ b/components/SmsOptInModal.tsx
@@ -1,0 +1,228 @@
+'use client'
+
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import { toast } from '@/components/ui/use-toast'
+import { MessageSquare, Phone, Check } from 'lucide-react'
+
+interface SmsOptInFormValues {
+  phone_number: string
+  first_name: string
+  last_name: string
+  consent: boolean
+}
+
+interface SmsOptInModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  coupleName?: string
+}
+
+export const SmsOptInModal = ({ open, onOpenChange, coupleName }: SmsOptInModalProps) => {
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isSuccess, setIsSuccess] = useState(false)
+
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    watch,
+    reset,
+    formState: { errors },
+  } = useForm<SmsOptInFormValues>({
+    defaultValues: {
+      phone_number: '',
+      first_name: '',
+      last_name: '',
+      consent: false,
+    },
+  })
+
+  const consentChecked = watch('consent')
+
+  const handleClose = () => {
+    onOpenChange(false)
+    // Reset form after modal closes
+    setTimeout(() => {
+      reset()
+      setIsSuccess(false)
+    }, 300)
+  }
+
+  const onSubmit = async (data: SmsOptInFormValues) => {
+    if (!data.consent) {
+      toast({
+        title: 'Consent Required',
+        description: 'Please check the consent checkbox to receive SMS notifications.',
+        variant: 'destructive',
+      })
+      return
+    }
+
+    setIsSubmitting(true)
+
+    try {
+      const response = await fetch('/api/sms-consent', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          phone_number: data.phone_number,
+          first_name: data.first_name,
+          last_name: data.last_name,
+        }),
+      })
+
+      const result = await response.json()
+
+      if (result.success) {
+        setIsSuccess(true)
+        toast({
+          title: 'Successfully Subscribed!',
+          description: 'You will now receive SMS notifications about the wedding.',
+        })
+      } else {
+        toast({
+          title: 'Error',
+          description: result.error || 'Failed to subscribe. Please try again.',
+          variant: 'destructive',
+        })
+      }
+    } catch (error) {
+      console.error('SMS opt-in error:', error)
+      toast({
+        title: 'Error',
+        description: 'An unexpected error occurred. Please try again.',
+        variant: 'destructive',
+      })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const displayName = coupleName || 'the couple'
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-gold-100">
+            <MessageSquare className="h-6 w-6 text-gold-600" aria-hidden="true" />
+          </div>
+          <DialogTitle className="text-center text-xl">
+            {isSuccess ? "You're Subscribed!" : 'SMS Notifications'}
+          </DialogTitle>
+          <DialogDescription className="text-center">
+            {isSuccess
+              ? `You'll receive text updates about ${displayName}'s wedding.`
+              : `Get wedding updates and reminders via text message from ${displayName}.`}
+          </DialogDescription>
+        </DialogHeader>
+
+        {isSuccess ? (
+          <div className="py-6 text-center">
+            <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-green-100">
+              <Check className="h-8 w-8 text-green-600" aria-hidden="true" />
+            </div>
+            <p className="text-gray-600 text-sm">
+              You can reply STOP at any time to unsubscribe from SMS notifications.
+            </p>
+            <Button onClick={handleClose} className="mt-6" variant="default">
+              Done
+            </Button>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+            {/* Phone Number */}
+            <div className="space-y-2">
+              <Label htmlFor="sms-phone">
+                Phone Number <span className="text-red-500">*</span>
+              </Label>
+              <div className="relative">
+                <Phone
+                  className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
+                  aria-hidden="true"
+                />
+                <Input
+                  id="sms-phone"
+                  type="tel"
+                  placeholder="+1 (555) 123-4567"
+                  className={`pl-10 ${errors.phone_number ? 'border-red-500' : ''}`}
+                  {...register('phone_number', {
+                    required: 'Phone number is required',
+                    pattern: {
+                      value: /^[\d\s\-\+\(\)]+$/,
+                      message: 'Please enter a valid phone number',
+                    },
+                    minLength: {
+                      value: 10,
+                      message: 'Phone number must be at least 10 digits',
+                    },
+                  })}
+                  aria-describedby={errors.phone_number ? 'phone-error' : undefined}
+                />
+              </div>
+              {errors.phone_number && (
+                <p id="phone-error" className="text-sm text-red-600" role="alert">
+                  {errors.phone_number.message}
+                </p>
+              )}
+            </div>
+
+            {/* Name Fields */}
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="sms-first-name">First Name</Label>
+                <Input id="sms-first-name" type="text" placeholder="John" {...register('first_name')} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="sms-last-name">Last Name</Label>
+                <Input id="sms-last-name" type="text" placeholder="Doe" {...register('last_name')} />
+              </div>
+            </div>
+
+            {/* Consent Checkbox */}
+            <div className="flex items-start space-x-3 rounded-lg border border-gray-200 bg-gray-50 p-4">
+              <Checkbox
+                id="sms-consent"
+                checked={consentChecked}
+                onCheckedChange={(checked) => setValue('consent', checked === true)}
+                aria-describedby="consent-description"
+              />
+              <div className="space-y-1">
+                <Label htmlFor="sms-consent" className="text-sm font-medium leading-tight cursor-pointer">
+                  I agree to receive SMS notifications <span className="text-red-500">*</span>
+                </Label>
+                <p id="consent-description" className="text-xs text-gray-500 leading-relaxed">
+                  By checking this box, you consent to receive text messages about wedding updates, reminders,
+                  and announcements. Message and data rates may apply. Reply STOP to unsubscribe at any time.
+                </p>
+              </div>
+            </div>
+
+            <DialogFooter className="flex-col gap-2 sm:flex-row">
+              <Button type="button" variant="outline" onClick={handleClose} className="w-full sm:w-auto">
+                Cancel
+              </Button>
+              <Button type="submit" disabled={isSubmitting || !consentChecked} className="w-full sm:w-auto">
+                {isSubmitting ? 'Subscribing...' : 'Subscribe to SMS'}
+              </Button>
+            </DialogFooter>
+          </form>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+

--- a/supabase/migrations/20251206_sms_consent.sql
+++ b/supabase/migrations/20251206_sms_consent.sql
@@ -1,0 +1,64 @@
+-- Migration: Add SMS consent opt-in table for Twilio compliance
+-- Date: 2025-12-06
+-- Description: Creates a table to store SMS notification opt-in consent from guests
+
+-- Create sms_consent table
+CREATE TABLE IF NOT EXISTS sms_consent (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  wedding_id UUID NOT NULL REFERENCES weddings(id) ON DELETE CASCADE,
+  phone_number TEXT NOT NULL,
+  first_name TEXT,
+  last_name TEXT,
+  consent_given BOOLEAN NOT NULL DEFAULT true,
+  consent_message TEXT, -- Store the consent message they agreed to
+  consent_timestamp TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  ip_address TEXT, -- For audit trail
+  user_agent TEXT, -- For audit trail
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  
+  -- Each phone number can only have one consent record per wedding
+  UNIQUE(wedding_id, phone_number)
+);
+
+-- Add indexes for common queries
+CREATE INDEX IF NOT EXISTS idx_sms_consent_wedding ON sms_consent(wedding_id);
+CREATE INDEX IF NOT EXISTS idx_sms_consent_phone ON sms_consent(phone_number);
+CREATE INDEX IF NOT EXISTS idx_sms_consent_timestamp ON sms_consent(consent_timestamp);
+
+-- Enable RLS
+ALTER TABLE sms_consent ENABLE ROW LEVEL SECURITY;
+
+-- RLS Policies
+-- Public can insert (for opt-in from landing page)
+CREATE POLICY "Anyone can opt in for SMS consent"
+  ON sms_consent FOR INSERT
+  WITH CHECK (true);
+
+-- Wedding owners can view their consent records
+CREATE POLICY "Wedding owners can view SMS consent"
+  ON sms_consent FOR SELECT
+  USING (
+    public.has_wedding_admin_access(wedding_id)
+  );
+
+-- Wedding owners can update consent records
+CREATE POLICY "Wedding owners can update SMS consent"
+  ON sms_consent FOR UPDATE
+  USING (
+    public.has_wedding_admin_access(wedding_id)
+  )
+  WITH CHECK (
+    public.has_wedding_admin_access(wedding_id)
+  );
+
+-- Wedding owners can delete consent records
+CREATE POLICY "Wedding owners can delete SMS consent"
+  ON sms_consent FOR DELETE
+  USING (
+    public.has_wedding_admin_access(wedding_id)
+  );
+
+-- Comment on table
+COMMENT ON TABLE sms_consent IS 'Stores SMS notification opt-in consent for Twilio compliance';
+


### PR DESCRIPTION
This commit introduces a new feature for SMS consent management, allowing users to opt-in for SMS notifications about weddings. It includes the creation of a new API endpoint for handling SMS consent submissions, which validates phone numbers and stores consent records in a new database table. Additionally, a modal for SMS opt-in is added to the footer, along with a dedicated client component to manage the display and interactions. The footer component is refactored to utilize the new client component, enhancing the user experience for SMS notifications.